### PR TITLE
Quicker counter responses

### DIFF
--- a/includes/counter.php
+++ b/includes/counter.php
@@ -175,8 +175,8 @@ function tptn_parse_request( $wp ) {
 				$str .= ( false === $ttd ) ? ' ttde' : ' ttd' . $ttd;
 			}
 		}
-		Header( 'content-type: application/x-javascript' );
-		echo '<!-- ' . $str . ' -->';
+		header("HTTP/1.0 204 No Content");
+		header("Cache-Control: max-age=15, s-maxage=0");
 
 		// Stop anything else from loading as it is not needed.
 		exit;


### PR DESCRIPTION
* return a 204, allows counting with tracking pixel (eg. `<img src="/?top10…">`) as well as JS
* prevent shared caches from storing a response
* let individual clients cache for 15 seconds (reduces jitter and impact of obsessive reloading)

The current response have to be processed by a JavaScript interpreter and then discarded as junk. No Content is discarded immediately plus will work with tracking pixels so no JavaScript dependency is needed.