### PR TITLE
Make $ajax_tptn_tracker global

### DIFF
--- a/includes/tracker.php
+++ b/includes/tracker.php
@@ -12,7 +12,7 @@
  * @return void
  */
 function tptn_enqueue_scripts() {
-	global $post, $tptn_settings;
+	global $post, $tptn_settings, $ajax_tptn_tracker;;
 
 	if ( is_singular() && 'draft' !== $post->post_status && ! is_customize_preview() ) {
 

--- a/includes/tracker.php
+++ b/includes/tracker.php
@@ -12,7 +12,7 @@
  * @return void
  */
 function tptn_enqueue_scripts() {
-	global $post, $tptn_settings, $ajax_tptn_tracker;;
+	global $post, $tptn_settings, $ajax_tptn_tracker;
 
 	if ( is_singular() && 'draft' !== $post->post_status && ! is_customize_preview() ) {
 


### PR DESCRIPTION
So that, in my theme, I can do what I want, eg.

if ( defined( 'TOP_TEN_PLUGIN_DIR' ) ) {
             tptn_enqueue_scripts();
             global $ajax_tptn_tracker;
             echo "var ajax_tptn_tracker = " . wp_json_encode( $ajax_tptn_tracker ) . ';';
             echo "ajax_tptn_tracker['top_ten_id'] = " . $post->ID . ";";
             echo file_get_contents(TOP_TEN_PLUGIN_DIR . "/includes/js/top-10-tracker.js");
        }