### PR TITLE
Fix: It doesn't filter old posts

### DIFF
--- a/includes/public/display-posts.php
+++ b/includes/public/display-posts.php
@@ -373,7 +373,7 @@ function get_tptn_pop_posts( $args = array() ) {
 
 	// How old should the posts be?
 	if ( $args['how_old'] ) {
-		$where .= $wpdb->prepare( " AND $wpdb->posts.post_date > %s ", gmdate( 'Y-m-d H:m:s', $current_time - ( $args['how_old'] * DAY_IN_SECONDS ) ) );
+		$where .= $wpdb->prepare( " AND $wpdb->posts.post_date > %s ", gmdate( 'Y-m-d H:m:s', current_time( 'timestamp', 0 ) - ( $args['how_old'] * DAY_IN_SECONDS ) ) );
 	}
 
 	// Create the base GROUP BY clause.


### PR DESCRIPTION
The variable $current_time is not defined because it was moved to tptn_get_from_date() function. This caused that doesn't filter the "old post" based on the how_old argument.
--
_La variable $current_time no esta definida porque se movio a la funcion tptn_get_from-date() ocasionando que no se filtraran los posts "viejos" segun el argumento how_old._ 