### PR TITLE
Return the same number of posts for cached queries

### DIFF
--- a/includes/class-top-ten-query.php
+++ b/includes/class-top-ten-query.php
@@ -441,10 +441,11 @@ if ( ! class_exists( 'Top_Ten_Query' ) ) :
 				if ( ! empty( $post_ids ) ) {
 					$posts                = get_posts(
 						array(
-							'post__in'  => $post_ids,
-							'fields'    => $query->get( 'fields' ),
-							'orderby'   => 'post__in',
-							'post_type' => $query->get( 'post_type' ),
+							'include'     => $post_ids,
+							'fields'      => $query->get( 'fields' ),
+							'orderby'     => 'post__in',
+							'post_type'   => $query->get( 'post_type' ),
+							'post_status' => $query->get( 'post_status' ),
 						)
 					);
 					$query->found_posts   = count( $posts );


### PR DESCRIPTION
`get_posts()` by default has a limit of 5 posts so if the initial query had 10 posts the cached  one will only return 5. By using the `include` argument the function sets the correct `post__in` and `posts_per_page` arguments.
To ensure the same post status is returned I'm also passing the `post_status`  to `get_posts()` which is otherwise `publish` by default.

Related: https://developer.wordpress.org/reference/functions/get_posts/