### PR TITLE
Fix text domain on importer and widget strings

### DIFF
--- a/includes/admin/class-wpp-importer.php
+++ b/includes/admin/class-wpp-importer.php
@@ -87,36 +87,36 @@ class WPP_Importer {
 				<input type="hidden" name="action" value="top_ten_import_wpp">
 				<table class="form-table">
 					<tr>
-						<th scope="row"><?php esc_html_e( 'Import Mode', 'top-ten' ); ?></th>
+						<th scope="row"><?php esc_html_e( 'Import Mode', 'top-10' ); ?></th>
 						<td>
 							<fieldset>
-								<legend class="screen-reader-text"><?php esc_html_e( 'Import Mode', 'top-ten' ); ?></legend>
+								<legend class="screen-reader-text"><?php esc_html_e( 'Import Mode', 'top-10' ); ?></legend>
 								<label>
 									<input type="radio" name="import_mode" value="merge">
-									<span><?php esc_html_e( 'Merge data (add WPP counts to existing Top 10 counts)', 'top-ten' ); ?></span>
+									<span><?php esc_html_e( 'Merge data (add WPP counts to existing Top 10 counts)', 'top-10' ); ?></span>
 								</label>
 								<br>
 								<label>
 									<input type="radio" name="import_mode" value="replace" checked="checked">
-									<span><?php esc_html_e( 'Replace data (replace Top 10 counts with WPP counts)', 'top-ten' ); ?></span>
+									<span><?php esc_html_e( 'Replace data (replace Top 10 counts with WPP counts)', 'top-10' ); ?></span>
 								</label>
 							</fieldset>
-							<p class="description"><?php esc_html_e( 'Merge mode will add WPP counts to existing Top 10 counts, while replace mode will replace Top 10 counts with WPP counts if they exists for the same post.', 'top-ten' ); ?></p>
+							<p class="description"><?php esc_html_e( 'Merge mode will add WPP counts to existing Top 10 counts, while replace mode will replace Top 10 counts with WPP counts if they exists for the same post.', 'top-10' ); ?></p>
 						</td>
 					</tr>
 					<tr>
-						<th scope="row"><?php esc_html_e( 'Data to Import', 'top-ten' ); ?></th>
+						<th scope="row"><?php esc_html_e( 'Data to Import', 'top-10' ); ?></th>
 						<td>
 							<fieldset>
-								<legend class="screen-reader-text"><?php esc_html_e( 'Data to Import', 'top-ten' ); ?></legend>
+								<legend class="screen-reader-text"><?php esc_html_e( 'Data to Import', 'top-10' ); ?></legend>
 								<label>
 									<input type="radio" name="import_data" value="total" checked="checked">
-									<span><?php esc_html_e( 'Total counts only', 'top-ten' ); ?></span>
+									<span><?php esc_html_e( 'Total counts only', 'top-10' ); ?></span>
 								</label>
 								<br>
 								<label>
 									<input type="radio" name="import_data" value="daily">
-									<span><?php esc_html_e( 'Daily counts only', 'top-ten' ); ?></span>
+									<span><?php esc_html_e( 'Daily counts only', 'top-10' ); ?></span>
 								</label>
 								<br>
 								<label>
@@ -128,25 +128,25 @@ class WPP_Importer {
 						</td>
 					</tr>
 					<tr>
-						<th scope="row"><?php esc_html_e( 'Minimum View Count', 'top-ten' ); ?></th>
+						<th scope="row"><?php esc_html_e( 'Minimum View Count', 'top-10' ); ?></th>
 						<td>
 							<input type="number" name="min_views" value="1" min="1" step="1">
-							<p class="description"><?php esc_html_e( 'Only import posts with at least this many views. Use this setting to filter out posts with very few views.', 'top-ten' ); ?></p>
+							<p class="description"><?php esc_html_e( 'Only import posts with at least this many views. Use this setting to filter out posts with very few views.', 'top-10' ); ?></p>
 						</td>
 					</tr>
 					<tr>
-						<th scope="row"><?php esc_html_e( 'Dry Run', 'top-ten' ); ?></th>
+						<th scope="row"><?php esc_html_e( 'Dry Run', 'top-10' ); ?></th>
 						<td>
 							<label>
 								<input type="checkbox" name="dry_run" value="1" checked="checked">
-								<?php esc_html_e( 'Enable Dry Run (simulate import)', 'top-ten' ); ?>
+								<?php esc_html_e( 'Enable Dry Run (simulate import)', 'top-10' ); ?>
 							</label>
-							<p class="description"><?php esc_html_e( 'A dry run will simulate the import process without actually updating the database. This is useful for testing the import parameters.', 'top-ten' ); ?></p>
+							<p class="description"><?php esc_html_e( 'A dry run will simulate the import process without actually updating the database. This is useful for testing the import parameters.', 'top-10' ); ?></p>
 						</td>
 					</tr>
 					<?php if ( is_multisite() && is_network_admin() ) : ?>
 						<tr>
-							<th scope="row"><?php esc_html_e( 'Select Sites', 'top-ten' ); ?></th>
+							<th scope="row"><?php esc_html_e( 'Select Sites', 'top-10' ); ?></th>
 							<td>
 								<?php
 								$sites = get_sites();
@@ -165,7 +165,7 @@ class WPP_Importer {
 						</tr>
 					<?php endif; ?>
 				</table>
-				<?php submit_button( esc_html__( 'Run Import', 'top-ten' ), 'primary', 'submit', true, array( 'id' => 'top-ten-wpp-import-submit' ) ); ?>
+				<?php submit_button( esc_html__( 'Run Import', 'top-10' ), 'primary', 'submit', true, array( 'id' => 'top-ten-wpp-import-submit' ) ); ?>
 
 				<p id="top-ten-wpp-import-progress" class="hidden notice notice-info">
 				</p>
@@ -362,12 +362,12 @@ class WPP_Importer {
 	public function handle_import_request() {
 		// Verify nonce.
 		if ( ! isset( $_POST['top_ten_import_wpp_nonce_field'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['top_ten_import_wpp_nonce_field'] ) ), 'top_ten_import_wpp_nonce' ) ) {
-			wp_die( esc_html__( 'Nonce verification failed', 'top-ten' ) );
+			wp_die( esc_html__( 'Nonce verification failed', 'top-10' ) );
 		}
 
 		// Check user capabilities.
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html__( 'You are not allowed to perform this action', 'top-ten' ) );
+			wp_die( esc_html__( 'You are not allowed to perform this action', 'top-10' ) );
 		}
 
 		// Get import parameters using our helper method.
@@ -384,7 +384,7 @@ class WPP_Importer {
 		}
 
 		if ( empty( $sites ) ) {
-			wp_die( esc_html__( 'No sites selected for import.', 'top-ten' ) );
+			wp_die( esc_html__( 'No sites selected for import.', 'top-10' ) );
 		}
 
 		$import_results = array();
@@ -421,10 +421,10 @@ class WPP_Importer {
 		foreach ( $import_results as $blog_id => $result ) {
 			$blog_details = get_blog_details( $blog_id );
 			/* translators: 1. Blog ID. */
-			$blog_name = $blog_details ? $blog_details->blogname : sprintf( __( 'Blog ID %d', 'top-ten' ), $blog_id );
+			$blog_name = $blog_details ? $blog_details->blogname : sprintf( __( 'Blog ID %d', 'top-10' ), $blog_id );
 			$message  .= sprintf(
 				/* translators: 1: Site name, 2: Blog ID, 3: Total records processed, 4: Daily records processed, 5: Dry run notice */
-				__( 'Site %1$s (ID: %2$d): Total Counts Processed: %3$d, Daily Records Processed: %4$d%5$s', 'top-ten' ),
+				__( 'Site %1$s (ID: %2$d): Total Counts Processed: %3$d, Daily Records Processed: %4$d%5$s', 'top-10' ),
 				esc_html( $blog_name ),
 				$blog_id,
 				$result['total_counts'] ?? 0,

--- a/includes/admin/class-wpp-importer.php
+++ b/includes/admin/class-wpp-importer.php
@@ -101,7 +101,7 @@ class WPP_Importer {
 									<span><?php esc_html_e( 'Replace data (replace Top 10 counts with WPP counts)', 'top-10' ); ?></span>
 								</label>
 							</fieldset>
-							<p class="description"><?php esc_html_e( 'Merge mode will add WPP counts to existing Top 10 counts, while replace mode will replace Top 10 counts with WPP counts if they exists for the same post.', 'top-10' ); ?></p>
+							<p class="description"><?php esc_html_e( 'Merge mode will add WPP counts to existing Top 10 counts, while replace mode will replace Top 10 counts with WPP counts if they exist for the same post.', 'top-10' ); ?></p>
 						</td>
 					</tr>
 					<tr>

--- a/includes/frontend/widgets/class-count-widget.php
+++ b/includes/frontend/widgets/class-count-widget.php
@@ -26,7 +26,7 @@ class Count_Widget extends \WP_Widget {
 			'widget_tptn_count', // Base ID.
 			__( 'Overall count [Top 10]', 'top-10' ), // Name.
 			array(
-				'description'                 => __( 'Display overall count', 'where-did-they-go-from-here' ),
+				'description'                 => __( 'Display overall count', 'top-10' ),
 				'customize_selective_refresh' => true,
 				'classname'                   => 'tptn_posts_count_widget',
 			)

--- a/includes/frontend/widgets/class-posts-widget.php
+++ b/includes/frontend/widgets/class-posts-widget.php
@@ -28,7 +28,7 @@ class Posts_Widget extends \WP_Widget {
 			'widget_tptn_pop', // Base ID.
 			__( 'Popular Posts [Top 10]', 'top-10' ), // Name.
 			array(
-				'description'                 => __( 'Display popular posts', 'where-did-they-go-from-here' ),
+				'description'                 => __( 'Display popular posts', 'top-10' ),
 				'classname'                   => 'tptn_posts_list_widget',
 				'customize_selective_refresh' => true,
 				'show_instance_in_rest'       => true,


### PR DESCRIPTION
Text-domain fix. The plugin header declares `Text Domain: top-10`, but the WPP importer screen tags its strings with `'top-ten'`, and two widget descriptions use `'where-did-they-go-from-here'` (a different plugin's domain). Those strings never load a translation, so they stay English even when the rest of the plugin is translated.

This points them all at `'top-10'` to match the header and the ~600 sibling calls. I was careful to change only the translation-function domain arguments. The HTML ids, script handles, and the `'top-ten'` export-filename component that also appear in those files are left exactly as they were.

Top 10 has held up really well over the years, and the string handling is otherwise consistent, which made the odd ones out easy to spot.

(full disclosure: AI helped me find the mismatches and scope the change; the edit and this note are mine.)
